### PR TITLE
allow for before_start and before_commit hooks

### DIFF
--- a/lib/releasetool/base_hooks.rb
+++ b/lib/releasetool/base_hooks.rb
@@ -8,13 +8,5 @@ module Releasetool
     def initialize(config)
       @config = config
     end
-
-    def after_prepare(version)
-      # noop
-    end
-
-    def after_commit(version)
-      # noop
-    end
   end
 end

--- a/lib/releasetool/configuration.rb
+++ b/lib/releasetool/configuration.rb
@@ -21,7 +21,7 @@ module Releasetool
       hook = :"#{before_after}_#{event}"
       return nil unless hooks.respond_to?(hook)
 
-      hooks.send(hook, version)
+      hooks.public_send(hook, version)
     end
 
     def generate

--- a/lib/releasetool/configuration.rb
+++ b/lib/releasetool/configuration.rb
@@ -5,16 +5,23 @@ require "pathname"
 
 module Releasetool
   class Configuration
-    def after_start_hook(version)
-      return nil unless hooks.respond_to?(:after_start)
+    BEFORE_AFTER = %i[before after].freeze
+    EVENTS = %i[start commit].freeze
 
-      hooks.after_start(version)
+    def around_hooks(event, version)
+      run_hook_for(:before, event, version)
+      yield
+      run_hook_for(:after, event, version)
     end
 
-    def after_commit_hook(version)
-      return nil unless hooks.respond_to?(:after_commit)
+    def run_hook_for(before_after, event, version)
+      raise "before_after must be in #{BEFORE_AFTER.inspect}" unless BEFORE_AFTER.include?(before_after)
+      raise "event must be in #{EVENTS.inspect}" unless EVENTS.include?(event)
 
-      hooks.after_commit(version)
+      hook = :"#{before_after}_#{event}"
+      return nil unless hooks.respond_to?(hook)
+
+      hooks.send(hook, version)
     end
 
     def generate
@@ -61,8 +68,16 @@ module Releasetool
           class Hooks < Releasetool::BaseHooks
             include Releasetool::Util
 
+            # def before_start(version)
+            #   puts "before_start has been called"
+            # end
+
             # def after_start(version)
             #   puts "after_start has been called"
+            # end
+
+            # def before_commit(version)
+            #   puts "before_commit has been called"
             # end
 
             # def after_commit(version)

--- a/spec/fixtures/hooks_example.rb
+++ b/spec/fixtures/hooks_example.rb
@@ -7,8 +7,16 @@ module Releasetool
   class Hooks < Releasetool::BaseHooks
     include Releasetool::Util
 
+    def before_start(version)
+      puts "before_start(#{version}) has been called"
+    end
+
     def after_start(version)
       puts "after_start(#{version}) has been called"
+    end
+
+    def before_commit(version)
+      puts "before_commit(#{version}) has been called"
     end
 
     def after_commit(version)

--- a/spec/releasetool_spec.rb
+++ b/spec/releasetool_spec.rb
@@ -123,8 +123,12 @@ RSpec.describe Release, quietly: true do
           FileUtils.cp(hooks_example_rb, "#{tmpdir}/config/releasetool/hooks.rb")
         end
         it "should output hook" do
-          expected = "after_start(v0.0.2) has been called"
-          expect { subject.start }.to output(/#{Regexp.escape(expected)}/).to_stdout
+          outputs = [
+            "before_start(v0.0.2) has been called",
+            "after_start(v0.0.2) has been called"
+          ]
+          expected_output = /#{outputs.map { |output| Regexp.escape(output) }.join('.*')}/m
+          expect { subject.start }.to output(expected_output).to_stdout
         end
       end
     end
@@ -173,8 +177,12 @@ RSpec.describe Release, quietly: true do
         FileUtils.cp(hooks_example_rb, "#{tmpdir}/config/releasetool/hooks.rb")
       end
       it "should output hook" do
-        expected = "after_commit(v0.0.3) has been called"
-        expect { subject.commit("v0.0.3") }.to output(/#{Regexp.escape(expected)}/).to_stdout
+        outputs = [
+          "before_commit(v0.0.3) has been called",
+          "after_commit(v0.0.3) has been called"
+        ]
+        expected_output = /#{outputs.map { |output| Regexp.escape(output) }.join('.*')}/m
+        expect { subject.commit("v0.0.3") }.to output(expected_output).to_stdout
       end
       context "with --after" do
         let(:options) { { after: true } }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add support for `before_start` and `before_commit` hooks

- Refactor hook system to use generic `around_hooks` method

- Support both before and after lifecycle events

- Update tests and examples to verify new hooks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hook System"] -->|"Refactored to"| B["around_hooks Method"]
  B -->|"Supports"| C["before_start"]
  B -->|"Supports"| D["after_start"]
  B -->|"Supports"| E["before_commit"]
  B -->|"Supports"| F["after_commit"]
  G["Release Tasks"] -->|"Uses"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_hooks.rb</strong><dd><code>Remove deprecated noop hook methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/releasetool/base_hooks.rb

<ul><li>Removed <code>after_prepare</code> and <code>after_commit</code> noop methods<br> <li> Simplified base class to only contain initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/red56/releasetool/pull/19/files#diff-231569edf5dc294033a7a41584c955927c6af876aa85ee14502336a7e82ea856">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.rb</strong><dd><code>Refactor hook system to support before/after events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/releasetool/configuration.rb

<ul><li>Replaced individual hook methods with generic <code>around_hooks</code> method<br> <li> Added <code>run_hook_for</code> method supporting before/after and start/commit <br>events<br> <li> Added constants <code>BEFORE_AFTER</code> and <code>EVENTS</code> for validation<br> <li> Updated generated hooks template with new hook examples</ul>


</details>


  </td>
  <td><a href="https://github.com/red56/releasetool/pull/19/files#diff-4063ed62aba1aac5539368d684597867fa27671d5ed6db54a62bd4753c2a9486">+21/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release_thor.rb</strong><dd><code>Update release tasks to use new hook system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/tasks/release_thor.rb

<ul><li>Updated <code>start</code> method to use <code>around_hooks(:start, version)</code> wrapper<br> <li> Updated <code>commit</code> method to call <code>run_hook_for(:before, :commit, version)</code><br> <li> Changed <code>after_commit_hook</code> call to <code>run_hook_for(:after, :commit, </code><br><code>version)</code><br> <li> Added minor formatting improvements</ul>


</details>


  </td>
  <td><a href="https://github.com/red56/releasetool/pull/19/files#diff-3488ddcd6b13faeb0ada3ce2dd26347649ecdbe9c15c3c71c1b62e7abe32e4c3">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hooks_example.rb</strong><dd><code>Add before hook examples to fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/fixtures/hooks_example.rb

<ul><li>Added <code>before_start</code> hook implementation with output<br> <li> Added <code>before_commit</code> hook implementation with output<br> <li> Kept existing <code>after_start</code> and <code>after_commit</code> hooks</ul>


</details>


  </td>
  <td><a href="https://github.com/red56/releasetool/pull/19/files#diff-21dcfe7980ab972aa1230a14d8e5e94f3d5f92b1279226c0937c1b032547aa39">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>releasetool_spec.rb</strong><dd><code>Update tests for new before hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/releasetool_spec.rb

<ul><li>Updated <code>start</code> test to expect both <code>before_start</code> and <code>after_start</code> outputs<br> <li> Updated <code>commit</code> test to expect both <code>before_commit</code> and <code>after_commit</code> <br>outputs<br> <li> Changed test assertions to use regex matching for multiple outputs</ul>


</details>


  </td>
  <td><a href="https://github.com/red56/releasetool/pull/19/files#diff-e4d87626cb1b691d69ed1c738b9d23a000157b7de735eb326b897a471a5524ba">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

